### PR TITLE
Feat/coords from nlp

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -49,6 +49,9 @@ const Chat = () => {
       setValue(key, value)
     })
 
+    // Sync center toggle with whether radius is being applied
+    setValue('center', 'radius' in filters)
+
     // Always set unknowns (even if empty)
     setValue('unknowns', unknowns)
 

--- a/src/components/ParamsPanel/ParamsPanel.tsx
+++ b/src/components/ParamsPanel/ParamsPanel.tsx
@@ -83,7 +83,7 @@ const ParamsPanel = () => {
             <TimerangeSection />
             <StatisticsSection />
             <ClustersSection />
-            {/* <CenterRadiusSection /> */}
+            <CenterRadiusSection />
             <BoundsSection />
           </>
         )

--- a/src/components/ParamsPanel/ParamsPanel.tsx
+++ b/src/components/ParamsPanel/ParamsPanel.tsx
@@ -143,6 +143,7 @@ const ParamsPanel = () => {
         const searchParams = {
           ...filteredParams,
           ...fetchBounds,
+          ...getCenterPoint(params, position),
           ...unknowns
         }
 

--- a/src/components/ParamsPanel/utils.ts
+++ b/src/components/ParamsPanel/utils.ts
@@ -66,7 +66,8 @@ export const filterQueryParams = (params: Partial<FormParams> = {}) => {
     ...(!params.stats ? statsOnlyParams : []),
     ...(!params.cluster ? clusterOnlyParams : []),
     ...(params.tab !== 'locations' ? searchOnlyParams : []),
-    ...(params.tab === 'locations' ? listingsOnlyParams : [])
+    ...(params.tab === 'locations' ? listingsOnlyParams : []),
+    ...(!params.center ? ['radius'] : []) // radius requires lat/long which only exist when center is enabled
   ]
 
   const maybeArrays = [


### PR DESCRIPTION
Enables proximity (center/radius) filtering to be applied from chat/NLP-derived parameters by exposing the Center/Radius UI and ensuring map center coordinates are included in search requests when the feature is enabled.

Changes:

- Render CenterRadiusSection in the main (map/stats) ParamsPanel flow.
- Include { lat, long, radius } in search and locations requests when center is enabled.
- Prevent sending radius when center is disabled; sync center toggle from chat when a radius filter is present.
