### PR TITLE
fix: prevent useLocationId param leakage from AI Listing Search into …

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,6 +81,14 @@ ParamsPanel UI → react-hook-form (ParamsFormProvider) → SearchProvider.setPa
 
 6. **Validated options** — if the field accepts only specific string values, add an `as const` array + type export to `types.ts` (like `classOptions`, `sortByOptions`) and reference it in both the schema (`Joi.string().valid(...myOptions)`) and the UI control's `options` prop.
 
+7. **Endpoint filtering** — add the field to the correct array in `src/constants/form.ts`:
+   - `customFormParams` — app-internal params that should NEVER reach any API endpoint (NLP params, UI state like `tab`, `sections`, etc.)
+   - `listingOnlyParams` — params sent only to the single-listing endpoint
+   - `searchOnlyParams` — params sent only to search/locations endpoints
+   - `clusterOnlyParams` / `statsOnlyParams` — params scoped to those endpoints
+
+   Missing this causes params to either leak into wrong API requests or get silently dropped.
+
 ### Example: adding a `minLotSize` filter
 
 ```ts

--- a/src/constants/form.ts
+++ b/src/constants/form.ts
@@ -29,6 +29,7 @@ export const customFormParams: (keyof CustomFormParams)[] = [
   'nlpId',
   'nlpLat',
   'nlpLong',
+  'nlpUseLocationId',
   'unknowns'
 ]
 


### PR DESCRIPTION
[fix: prevent useLocationId param leakage from AI Listing Search into other tabs](https://github.com/Repliers-io/dev-playgrounds/commit/8738425b8f80d6a6f2214736c8c4b9b365ba702f)